### PR TITLE
Stub out GamesController

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,1 +1,4 @@
-# Code your GamesController here
+class GamesController < ApplicationController
+  # Add your GamesController code here
+
+end


### PR DESCRIPTION
so that test suite fails properly instead of with a '1 error occurred outside of examples' message, which is not registered by Ironboard as a failure and therefore causes the 'Run Local Tests' light to turn green